### PR TITLE
Fix create script to resolve relative paths

### DIFF
--- a/create.sh
+++ b/create.sh
@@ -2,8 +2,10 @@
 
 if [ -z "$1" ]; then
 	dest=$(pwd)/out
-else
+elif [[ "$1" = /* ]]; then
 	dest=$1
+else 
+	dest=$(pwd)/$1
 fi
 
 export dod_url=https://github.com/iankoulski/depend-on-docker/trunk/linux/


### PR DESCRIPTION
Relative paths were not being resolved to aboslute paths before being
passed to docker -v, which would then create volumes within the docker
VM instead of directories on the host at the desired location. Fix
checks if a relative path is provided, and prepends the working
directory.